### PR TITLE
Made UrlDetector work with color codes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ buildNumber.properties
 .idea/
 /.classpath
 /.project
+/VentureChat.iml

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.1.0</version>
         </dependency>
         <!--These are long depreciated. I would've removed them, but that is outside the scope of what I want to do here.
         I am using the latest builds of these plugins to be published to SpigotMC.-->
@@ -173,9 +173,9 @@
             <systemPath>${basedir}/lib/MassiveCore.jar</systemPath>
         </dependency>
         <dependency>
-          <groupId>com.linkedin.urls</groupId>
+          <groupId>io.github.url-detector</groupId>
           <artifactId>url-detector</artifactId>
-          <version>0.1.17</version>
+          <version>0.1.23</version>
           <scope>provided</scope>
         </dependency>
         <!--Back to safety.-->

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -3,4 +3,4 @@ main: mineverse.Aust1n46.chat.proxy.VentureChatBungee
 version: ${project.version}
 author: Aust1n46
 libraries:
-  - com.linkedin.urls:url-detector:0.1.17
+  - io.github.url-detector:url-detector:0.1.23

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,4 +8,4 @@ author: Aust1n46
 website: https://bitbucket.org/Aust1n46/venturechat/
 description: #1 Channels Chat plugin! Spigot + Bungee. Supports PlaceholderAPI + JSON formatting. Moderation GUI!
 libraries:
-  - com.linkedin.urls:url-detector:0.1.17
+  - io.github.url-detector:url-detector:0.1.23


### PR DESCRIPTION
Ich konnte es nicht auf mir sitzen lassen, dass ein Pattern besser sein soll, als der URL-detector.
Also funktioniert der Detektor jetzt auch mit Farbcodes, die man - im Gegensatz zum Pattern - an beliebiger stelle ohne Beschränkungen einfügen kann und trotzdem von der Vollständigkeit des Detectors profitiert.

Ja ich habe einen Schaden. Danke der Nachfrage.